### PR TITLE
Change naming of java types and add attribute to Type

### DIFF
--- a/src/main/java/de/dhbw/compiler/ast/Type.java
+++ b/src/main/java/de/dhbw/compiler/ast/Type.java
@@ -1,4 +1,4 @@
 package de.dhbw.compiler.ast;
 
-public record Type() {
+public record Type(String name) {
 }

--- a/src/main/java/de/dhbw/compiler/ast/expressions/Bool.java
+++ b/src/main/java/de/dhbw/compiler/ast/expressions/Bool.java
@@ -1,4 +1,0 @@
-package de.dhbw.compiler.ast.expressions;
-
-public record Bool(Boolean value) implements Expression {
-}

--- a/src/main/java/de/dhbw/compiler/ast/expressions/Char.java
+++ b/src/main/java/de/dhbw/compiler/ast/expressions/Char.java
@@ -1,4 +1,0 @@
-package de.dhbw.compiler.ast.expressions;
-
-public record Char(Character value) implements Expression {
-}

--- a/src/main/java/de/dhbw/compiler/ast/expressions/Expression.java
+++ b/src/main/java/de/dhbw/compiler/ast/expressions/Expression.java
@@ -1,5 +1,5 @@
 package de.dhbw.compiler.ast.expressions;
 
 public sealed interface Expression permits
-    This, Super, LocalOrFieldVar, InstVar, Unary, Binary, Integr, Bool, Char, Strng, Jnull, StmtExprExpr {
+    This, Super, LocalOrFieldVar, InstVar, Unary, Binary, JInteger, JBoolean, JCharacter, JString, Jnull, StmtExprExpr {
 }

--- a/src/main/java/de/dhbw/compiler/ast/expressions/Integr.java
+++ b/src/main/java/de/dhbw/compiler/ast/expressions/Integr.java
@@ -1,4 +1,0 @@
-package de.dhbw.compiler.ast.expressions;
-
-public record Integr(Integer value) implements Expression {
-}

--- a/src/main/java/de/dhbw/compiler/ast/expressions/JBoolean.java
+++ b/src/main/java/de/dhbw/compiler/ast/expressions/JBoolean.java
@@ -1,0 +1,4 @@
+package de.dhbw.compiler.ast.expressions;
+
+public record JBoolean(Boolean value) implements Expression {
+}

--- a/src/main/java/de/dhbw/compiler/ast/expressions/JCharacter.java
+++ b/src/main/java/de/dhbw/compiler/ast/expressions/JCharacter.java
@@ -1,0 +1,4 @@
+package de.dhbw.compiler.ast.expressions;
+
+public record JCharacter(Character value) implements Expression {
+}

--- a/src/main/java/de/dhbw/compiler/ast/expressions/JInteger.java
+++ b/src/main/java/de/dhbw/compiler/ast/expressions/JInteger.java
@@ -1,0 +1,4 @@
+package de.dhbw.compiler.ast.expressions;
+
+public record JInteger(Integer value) implements Expression {
+}

--- a/src/main/java/de/dhbw/compiler/ast/expressions/JString.java
+++ b/src/main/java/de/dhbw/compiler/ast/expressions/JString.java
@@ -1,0 +1,4 @@
+package de.dhbw.compiler.ast.expressions;
+
+public record JString(String value) implements Expression {
+}

--- a/src/main/java/de/dhbw/compiler/ast/expressions/Strng.java
+++ b/src/main/java/de/dhbw/compiler/ast/expressions/Strng.java
@@ -1,4 +1,0 @@
-package de.dhbw.compiler.ast.expressions;
-
-public record Strng(String value) implements Expression {
-}


### PR DESCRIPTION
Fixes Type class and naming of java types as discussed. JBoolean and JCharacter might not be necessary but but are nice for uniform naming.