### PR TITLE
chore(tests): add JUnit DisplayNames to remove warnings

### DIFF
--- a/src/test/java/de/dhbw/compiler/ast/ClazzTest.java
+++ b/src/test/java/de/dhbw/compiler/ast/ClazzTest.java
@@ -16,12 +16,12 @@ public class ClazzTest {
         clazz1 = new Clazz( null, null, null, null);
     }
     @Test
-    @DisplayName("")
+    @DisplayName("getTypeTest")
     void getTypeTest(){
         assertEquals(PrimitiveType.BOOLEAN, clazz0.getType() );
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setTypeTest")
     void setTypeTest1(){
         clazz0.setType(PrimitiveType.INTEGER);
         assertEquals(PrimitiveType.INTEGER, clazz0.getType() );

--- a/src/test/java/de/dhbw/compiler/ast/ConstructorTest.java
+++ b/src/test/java/de/dhbw/compiler/ast/ConstructorTest.java
@@ -26,34 +26,34 @@ public class ConstructorTest {
     }
     //How shoud I accept(MethodeCodeVisitor
     @Test
-    @DisplayName("")
+    @DisplayName("getParameterTest")
     void getParameterTest(){
         assertEquals(parameterList, constructor0.getParameterList());
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setParameterTest")
     void setParameterTest(){
         constructor0.setParameterList(parameterList1);
         assertEquals(parameterList1, constructor0.getParameterList());
     }
     @Test
-    @DisplayName("")
+    @DisplayName("getBodyTest")
     void getBodyTest(){
         assertEquals(body, constructor0.getBody());
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setBodyTest")
     void setBodyTest(){
         constructor0.setBody(body1);
         assertEquals(body1, constructor0.getBody());
     }
     @Test
-    @DisplayName("")
+    @DisplayName("getTypeTest")
     void getTypeTest(){
         assertEquals(PrimitiveType.BOOLEAN, constructor0.getType());
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setTypeTest")
     void setTypeTest(){
         constructor0.setType(PrimitiveType.INTEGER);
         assertEquals(PrimitiveType.INTEGER, constructor0.getType());

--- a/src/test/java/de/dhbw/compiler/ast/FieldTest.java
+++ b/src/test/java/de/dhbw/compiler/ast/FieldTest.java
@@ -16,12 +16,12 @@ public class FieldTest {
         field1 = new Field( null,  null);
     }
     @Test
-    @DisplayName("")
+    @DisplayName("getTypeTest")
     void getTypeTest(){
         assertEquals(PrimitiveType.BOOLEAN, field0.getType() );
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setTypeTest1")
     void setTypeTest1(){
         field0.setType(PrimitiveType.INTEGER);
         assertEquals(PrimitiveType.INTEGER, field0.getType() );

--- a/src/test/java/de/dhbw/compiler/ast/MethodTest.java
+++ b/src/test/java/de/dhbw/compiler/ast/MethodTest.java
@@ -17,12 +17,12 @@ public class MethodTest {
         method1 = new Method( null, null, null, null);
     }
     @Test
-    @DisplayName("")
+    @DisplayName("getTypeTest")
     void getTypeTest(){
         assertEquals(PrimitiveType.BOOLEAN, method0.getType() );
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setTypeTest1")
     void setTypeTest1(){
         method0.setType(PrimitiveType.INTEGER);
         assertEquals(PrimitiveType.INTEGER, method0.getType() );

--- a/src/test/java/de/dhbw/compiler/ast/ParameterTest.java
+++ b/src/test/java/de/dhbw/compiler/ast/ParameterTest.java
@@ -19,23 +19,23 @@ public class ParameterTest {
         parameter1 = new Parameter(astType, "paramater1");
     }
     @Test
-    @DisplayName("")
+    @DisplayName("getTypeTest0")
     void getTypeTest0(){
         assertEquals(PrimitiveType.BOOLEAN, parameter0.getType() );
     }
     @Test
-    @DisplayName("")
+    @DisplayName("getTypeTest1")
     void getTypeTest1(){
         assertEquals(PrimitiveType.BOOLEAN, parameter1.getType() );
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setTypeTest0")
     void setTypeTest0(){
         parameter0.setType(PrimitiveType.INTEGER);
         assertEquals(PrimitiveType.INTEGER, parameter0.getType() );
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setTypeTest1")
     void setTypeTest1(){
         parameter1.setType(PrimitiveType.INTEGER);
         assertEquals(PrimitiveType.INTEGER, parameter1.getType() );

--- a/src/test/java/de/dhbw/compiler/ast/stmtexprs/AssignTest.java
+++ b/src/test/java/de/dhbw/compiler/ast/stmtexprs/AssignTest.java
@@ -18,12 +18,12 @@ public class AssignTest {
         assign1 = new Assign(null, null);
     }
     @Test
-    @DisplayName("")
+    @DisplayName("getTypeTest")
     void getTypeTest(){
         assertEquals(PrimitiveType.BOOLEAN, assign0.getType() );
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setTypeTest")
     void setTypeTest(){
         assign0.setType(PrimitiveType.INTEGER);
         assertEquals(PrimitiveType.INTEGER, assign0.getType() );

--- a/src/test/java/de/dhbw/compiler/ast/stmtexprs/MethodCallTest.java
+++ b/src/test/java/de/dhbw/compiler/ast/stmtexprs/MethodCallTest.java
@@ -18,12 +18,12 @@ public class MethodCallTest {
     }
     //again how should I test the accept
     @Test
-    @DisplayName("")
+    @DisplayName("getTypeTest")
     void getTypeTest(){
         assertEquals(PrimitiveType.BOOLEAN, methodCall0.getType() );
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setTypeTest")
     void setTypeTest(){
         methodCall0.setType(PrimitiveType.INTEGER);
         assertEquals(PrimitiveType.INTEGER, methodCall0.getType() );

--- a/src/test/java/de/dhbw/compiler/ast/stmtexprs/NewTest.java
+++ b/src/test/java/de/dhbw/compiler/ast/stmtexprs/NewTest.java
@@ -17,12 +17,12 @@ public class NewTest {
         new1 = new New(null, null);
     }
     @Test
-    @DisplayName("")
+    @DisplayName("getTypeTest")
     void getTypeTest(){
         assertEquals(PrimitiveType.BOOLEAN, new0.getType() );
     }
     @Test
-    @DisplayName("")
+    @DisplayName("setTypeTest")
     void setTypeTest(){
         new0.setType(PrimitiveType.INTEGER);
         assertEquals(PrimitiveType.INTEGER, new0.getType() );


### PR DESCRIPTION
Adds @DisplayName values to tests to remove warnings. There's also a lot of commented out code and unused imports in the test code, can that be removed? @JakobPK 